### PR TITLE
Fix an issue which observed when using with Streaming Integrator

### DIFF
--- a/component/pom.xml
+++ b/component/pom.xml
@@ -101,6 +101,9 @@
                             io.siddhi.query.api.*;version="${siddhi.version.range}",
                             *;resolution:=optional
                         </Import-Package>
+                        <Private-Package>
+                            org.apache.commons.csv.*;version="${commons.csv.version}"
+                        </Private-Package>
                         <Include-Resource>
                             META-INF=target/classes/META-INF
                         </Include-Resource>


### PR DESCRIPTION
## Purpose
> When using with Streaming integrator NoClassDefFoundError will thrown due to missing of org.apache.commons.csv.CSVFormat class

This Closes the issue wso2/streaming-integrator#12
