### PR TITLE
Add support for TSV

### DIFF
--- a/component/src/main/java/io/siddhi/extension/map/csv/sinkmapper/CSVSinkMapper.java
+++ b/component/src/main/java/io/siddhi/extension/map/csv/sinkmapper/CSVSinkMapper.java
@@ -119,6 +119,8 @@ public class CSVSinkMapper extends SinkMapper {
     private static final String DEFAULT_GROUP_EVENTS = "false";
     private static final String DEFAULT_HEADER = "false";
     private static final String DEFAULT_DELIMITER = ",";
+    private static final String TAB_DElIMITER_INPUT = "\\t";
+    private static final char TAB_DElIMITER = '\t';
 
     private StreamDefinition streamDefinition;
     private boolean eventGroupEnabled;
@@ -160,7 +162,7 @@ public class CSVSinkMapper extends SinkMapper {
         this.eventGroupEnabled = Boolean.valueOf(optionHolder.validateAndGetStaticValue(OPTION_GROUP_EVENTS,
                                                                                         DEFAULT_GROUP_EVENTS));
         String delimiterValue = optionHolder.getOrCreateOption(DELIMITER, DEFAULT_DELIMITER).getValue();
-        this.delimiter = "\\t".equals(delimiterValue) ? '\t' : delimiterValue.charAt(0);
+        this.delimiter = TAB_DElIMITER_INPUT.equals(delimiterValue) ? TAB_DElIMITER : delimiterValue.charAt(0);
         headerOfData = new Object[streamDefinition.getAttributeNameArray().length];
         if (payloadTemplateBuilderMap == null) {
             dataOfEvent = new Object[streamDefinition.getAttributeNameArray().length];

--- a/component/src/main/java/io/siddhi/extension/map/csv/sinkmapper/CSVSinkMapper.java
+++ b/component/src/main/java/io/siddhi/extension/map/csv/sinkmapper/CSVSinkMapper.java
@@ -159,7 +159,8 @@ public class CSVSinkMapper extends SinkMapper {
         this.header = Boolean.parseBoolean(optionHolder.getOrCreateOption(HEADER, DEFAULT_HEADER).getValue());
         this.eventGroupEnabled = Boolean.valueOf(optionHolder.validateAndGetStaticValue(OPTION_GROUP_EVENTS,
                                                                                         DEFAULT_GROUP_EVENTS));
-        this.delimiter = optionHolder.getOrCreateOption(DELIMITER, DEFAULT_DELIMITER).getValue().charAt(0);
+        String delimiterValue = optionHolder.getOrCreateOption(DELIMITER, DEFAULT_DELIMITER).getValue();
+        this.delimiter = "\\t".equals(delimiterValue) ? '\t' : delimiterValue.charAt(0);
         headerOfData = new Object[streamDefinition.getAttributeNameArray().length];
         if (payloadTemplateBuilderMap == null) {
             dataOfEvent = new Object[streamDefinition.getAttributeNameArray().length];

--- a/component/src/main/java/io/siddhi/extension/map/csv/sourcemapper/CSVSourceMapper.java
+++ b/component/src/main/java/io/siddhi/extension/map/csv/sourcemapper/CSVSourceMapper.java
@@ -142,6 +142,8 @@ public class CSVSourceMapper extends SourceMapper {
     private static final String OPTION_GROUP_EVENTS = "event.grouping.enabled";
     private static final String DEFAULT_FAIL_ON_UNKNOWN_ATTRIBUTE = "true";
     private static final String DEFAULT_EVENT_GROUP = "false";
+    private static final String TAB_DElIMITER_INPUT = "\\t";
+    private static final char TAB_DElIMITER = '\t';
 
     private boolean isCustomMappingEnabled = false;
     private StreamDefinition streamDefinition;
@@ -173,7 +175,7 @@ public class CSVSourceMapper extends SourceMapper {
         this.attributeTypeMap = new HashMap<>(attributeList.size());
         this.attributePositionMap = new HashMap<>(attributeList.size());
         String delimiterValue = optionHolder.validateAndGetStaticValue(MAPPING_DELIMETER, ",");
-        this.delimiter = "\\t".equals(delimiterValue) ? '\t' : delimiterValue.charAt(0);
+        this.delimiter = TAB_DElIMITER_INPUT.equals(delimiterValue) ? TAB_DElIMITER : delimiterValue.charAt(0);
         boolean header = Boolean.parseBoolean(optionHolder.validateAndGetStaticValue(MAPPING_HEADER, "false"));
         this.failOnUnknownAttribute = Boolean.parseBoolean(optionHolder.validateAndGetStaticValue(
                 FAIL_ON_UNKNOWN_ATTRIBUTE, DEFAULT_FAIL_ON_UNKNOWN_ATTRIBUTE));
@@ -323,7 +325,7 @@ public class CSVSourceMapper extends SourceMapper {
      * @return
      */
     private CSVFormat getFormatter(char delimiter) {
-        if (delimiter == '\t') {
+        if (delimiter == TAB_DElIMITER) {
             return CSVFormat.TDF;
         }
         return CSVFormat.DEFAULT.withDelimiter(delimiter);


### PR DESCRIPTION
## Purpose
This PR enables support for TSV files in the Sink and Source mappers.

## Approach
TSV files can be read and written with the following Siddhi codes.

Source mapper:
```
@source(type='file',
    dir.uri='file:/<TSV_PARENT_DIR>',
    action.after.process='NONE',
    @map(type='csv', delimiter="\t"))
define stream InputStream (id int, name string, amount double);
```

Sink mapper:
```
@sink(type='file', file.uri='<TSV_FILE_PATH> , 
    @map(type='csv', delimiter="\t"))
define stream OutputStream (id int, name string, amount double);
```

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes