### PR TITLE
Add multi character delimiter support for csv mapper

### DIFF
--- a/component/src/main/java/io/siddhi/extension/map/csv/sinkmapper/CSVSinkMapper.java
+++ b/component/src/main/java/io/siddhi/extension/map/csv/sinkmapper/CSVSinkMapper.java
@@ -67,14 +67,14 @@ import java.util.concurrent.atomic.AtomicBoolean;
                         optional = true, defaultValue = "false",
                         type = {DataType.BOOL}),
                 @Parameter(name = "event.grouping.enabled",
-                           description =
-                                   "If this parameter is set to `true`, events are grouped via a line.separator" +
-                                           " when multiple events are received. It is required to specify " +
-                                           "a value for the System.lineSeparator() when the value for this parameter" +
-                                           " is `true`.",
-                           type = {DataType.BOOL},
-                           optional = true,
-                           defaultValue = "false"),
+                        description =
+                                "If this parameter is set to `true`, events are grouped via a line.separator" +
+                                        " when multiple events are received. It is required to specify " +
+                                        "a value for the System.lineSeparator() when the value for this parameter" +
+                                        " is `true`.",
+                        type = {DataType.BOOL},
+                        optional = true,
+                        defaultValue = "false"),
         },
         examples = {
                 @Example(
@@ -120,11 +120,11 @@ public class CSVSinkMapper extends SinkMapper {
     private static final String DEFAULT_HEADER = "false";
     private static final String DEFAULT_DELIMITER = ",";
     private static final String TAB_DElIMITER_INPUT = "\\t";
-    private static final char TAB_DElIMITER = '\t';
+    private static final String TAB_DElIMITER = "\t";
 
     private StreamDefinition streamDefinition;
     private boolean eventGroupEnabled;
-    private char delimiter;
+    private String delimiter;
     private Boolean header;
     private Object[] headerOfData;
     private Object[] dataOfEvent;
@@ -160,9 +160,9 @@ public class CSVSinkMapper extends SinkMapper {
         this.streamDefinition = streamDefinition;
         this.header = Boolean.parseBoolean(optionHolder.getOrCreateOption(HEADER, DEFAULT_HEADER).getValue());
         this.eventGroupEnabled = Boolean.valueOf(optionHolder.validateAndGetStaticValue(OPTION_GROUP_EVENTS,
-                                                                                        DEFAULT_GROUP_EVENTS));
+                DEFAULT_GROUP_EVENTS));
         String delimiterValue = optionHolder.getOrCreateOption(DELIMITER, DEFAULT_DELIMITER).getValue();
-        this.delimiter = TAB_DElIMITER_INPUT.equals(delimiterValue) ? TAB_DElIMITER : delimiterValue.charAt(0);
+        this.delimiter = TAB_DElIMITER_INPUT.equals(delimiterValue) ? TAB_DElIMITER : delimiterValue;
         headerOfData = new Object[streamDefinition.getAttributeNameArray().length];
         if (payloadTemplateBuilderMap == null) {
             dataOfEvent = new Object[streamDefinition.getAttributeNameArray().length];
@@ -202,8 +202,8 @@ public class CSVSinkMapper extends SinkMapper {
                                             + streamDefinition.getId() + "' of siddhi CSV input mapper.");
                         } catch (AttributeNotExistException e) {
                             log.error("[ERROR] when arranging the attribute order, " + entry.getKey() +
-                                              " isn't in the '" + streamDefinition.getId() +
-                                              "' of siddhi custom CSV input mapper.");
+                                    " isn't in the '" + streamDefinition.getId() +
+                                    "' of siddhi custom CSV input mapper.");
                         }
                     }
                 }
@@ -235,12 +235,9 @@ public class CSVSinkMapper extends SinkMapper {
                            Map<String, TemplateBuilder> payloadTemplateBuilderMap, SinkListener sinkListener) {
         try {
             if (isAddHeader) {
-                CSVFormat.DEFAULT
-                        .withDelimiter(delimiter)
-                        .withRecordSeparator(System.lineSeparator())
-                        .withNullString("null")
-                        .withQuote('\"')
-                        .printRecord(stringWriter, headerOfData);
+                CSVFormat.Builder.create().setDelimiter(delimiter)
+                        .setRecordSeparator(System.lineSeparator())
+                        .setNullString("null").setQuote('\"').build().printRecord(stringWriter, headerOfData);
                 sinkListener.publish(stringWriter.toString());
                 isAddHeader = false;
                 stringWriter.getBuffer().setLength(0);
@@ -252,12 +249,11 @@ public class CSVSinkMapper extends SinkMapper {
                             dataOfEvent[i] = event.getData(streamDefinition.getAttributePosition(
                                     headerOfData[i].toString()));
                         }
-                        CSVFormat.DEFAULT
-                                .withDelimiter(delimiter)
-                                .withNullString("null")
-                                .withQuote('\"')
-                                .withRecordSeparator(System.lineSeparator())
-                                .printRecord(stringWriter, dataOfEvent);
+                        CSVFormat.Builder.create().setDelimiter(delimiter)
+                                .setNullString("null")
+                                .setQuote('\"')
+                                .setRecordSeparator(System.lineSeparator())
+                                .build().printRecord(stringWriter, dataOfEvent);
                     }
                     sinkListener.publish(stringWriter.toString());
                     stringWriter.getBuffer().setLength(0);
@@ -267,11 +263,10 @@ public class CSVSinkMapper extends SinkMapper {
                             dataOfEvent[i] = event.getData(streamDefinition.getAttributePosition(
                                     headerOfData[i].toString()));
                         }
-                        CSVFormat.DEFAULT
-                                .withDelimiter(delimiter)
-                                .withRecordSeparator(System.lineSeparator())
-                                .withNullString("null")
-                                .withQuote('\"')
+                        CSVFormat.Builder.create().setDelimiter(delimiter)
+                                .setRecordSeparator(System.lineSeparator())
+                                .setNullString("null")
+                                .setQuote('\"').build()
                                 .printRecord(stringWriter, dataOfEvent);
                         sinkListener.publish(stringWriter.toString());
                         stringWriter.getBuffer().setLength(0);
@@ -281,11 +276,11 @@ public class CSVSinkMapper extends SinkMapper {
                 if (eventGroupEnabled) {
                     for (Event event : events) {
                         dataOfEvent = event.getData();
-                        CSVFormat.DEFAULT
-                                .withDelimiter(delimiter)
-                                .withNullString("null")
-                                .withQuote('\"')
-                                .withRecordSeparator(System.lineSeparator())
+                        CSVFormat.Builder.create()
+                                .setDelimiter(delimiter)
+                                .setNullString("null")
+                                .setQuote('\"')
+                                .setRecordSeparator(System.lineSeparator()).build()
                                 .printRecord(stringWriter, dataOfEvent);
                     }
                     sinkListener.publish(stringWriter.toString());
@@ -293,11 +288,11 @@ public class CSVSinkMapper extends SinkMapper {
                 } else {
                     for (Event event : events) {
                         dataOfEvent = event.getData();
-                        CSVFormat.DEFAULT
-                                .withDelimiter(delimiter)
-                                .withRecordSeparator(System.lineSeparator())
-                                .withNullString("null")
-                                .withQuote('\"')
+                        CSVFormat.Builder.create()
+                                .setDelimiter(delimiter)
+                                .setRecordSeparator(System.lineSeparator())
+                                .setNullString("null")
+                                .setQuote('\"').build()
                                 .printRecord(stringWriter, dataOfEvent);
                         sinkListener.publish(stringWriter.toString());
                         stringWriter.getBuffer().setLength(0);
@@ -306,7 +301,7 @@ public class CSVSinkMapper extends SinkMapper {
             }
         } catch (IOException e) {
             log.error("[ERROR] Fail to print the data in csv format from Siddhi event in the stream  '"
-                              + streamDefinition.getId() + "' of siddhi CSV output mapper.", e);
+                    + streamDefinition.getId() + "' of siddhi CSV output mapper.", e);
         }
 
     }
@@ -332,21 +327,21 @@ public class CSVSinkMapper extends SinkMapper {
                 dataOfEvent = event.getData();
             }
             if (isAddHeader) {
-                CSVFormat.DEFAULT
-                        .withDelimiter(delimiter)
-                        .withRecordSeparator(System.lineSeparator())
-                        .withNullString("null")
-                        .withQuote('\"')
+                CSVFormat.Builder.create()
+                        .setDelimiter(delimiter)
+                        .setRecordSeparator(System.lineSeparator())
+                        .setNullString("null")
+                        .setQuote('\"').build()
                         .printRecord(stringWriter, headerOfData);
                 sinkListener.publish(stringWriter.toString());
                 isAddHeader = false;
                 stringWriter.getBuffer().setLength(0);
             }
-            CSVFormat.DEFAULT
-                    .withDelimiter(delimiter)
-                    .withRecordSeparator(System.lineSeparator())
-                    .withNullString("null")
-                    .withQuote('\"')
+            CSVFormat.Builder.create()
+                    .setDelimiter(delimiter)
+                    .setRecordSeparator(System.lineSeparator())
+                    .setNullString("null")
+                    .setQuote('\"').build()
                     .printRecord(stringWriter, dataOfEvent);
             sinkListener.publish(stringWriter.toString());
             stringWriter.getBuffer().setLength(0);

--- a/component/src/main/java/io/siddhi/extension/map/csv/sourcemapper/CSVSourceMapper.java
+++ b/component/src/main/java/io/siddhi/extension/map/csv/sourcemapper/CSVSourceMapper.java
@@ -46,6 +46,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * This mapper converts CSV string input to {@link io.siddhi.core.event.ComplexEventChunk}.
@@ -143,12 +144,12 @@ public class CSVSourceMapper extends SourceMapper {
     private static final String DEFAULT_FAIL_ON_UNKNOWN_ATTRIBUTE = "true";
     private static final String DEFAULT_EVENT_GROUP = "false";
     private static final String TAB_DElIMITER_INPUT = "\\t";
-    private static final char TAB_DElIMITER = '\t';
+    private static final String TAB_DElIMITER = "\t";
 
     private boolean isCustomMappingEnabled = false;
     private StreamDefinition streamDefinition;
     private boolean failOnUnknownAttribute;
-    private Object delimiter;
+    private String delimiter;
     private boolean eventGroupEnabled;
     private AttributeConverter attributeConverter = new AttributeConverter();
     private List<Attribute> attributeList;
@@ -175,13 +176,7 @@ public class CSVSourceMapper extends SourceMapper {
         this.attributeTypeMap = new HashMap<>(attributeList.size());
         this.attributePositionMap = new HashMap<>(attributeList.size());
         String delimiterValue = optionHolder.validateAndGetStaticValue(MAPPING_DELIMETER, ",");
-        if (TAB_DElIMITER_INPUT.equals(delimiterValue)) {
-            this.delimiter = TAB_DElIMITER;
-        } else if (delimiterValue.length() > 1) {
-            this.delimiter = delimiterValue;
-        } else {
-            this.delimiter = delimiterValue.charAt(0);
-        }
+        this.delimiter = TAB_DElIMITER_INPUT.equals(delimiterValue) ? TAB_DElIMITER : delimiterValue;
         boolean header = Boolean.parseBoolean(optionHolder.validateAndGetStaticValue(MAPPING_HEADER, "false"));
         this.failOnUnknownAttribute = Boolean.parseBoolean(optionHolder.validateAndGetStaticValue(
                 FAIL_ON_UNKNOWN_ATTRIBUTE, DEFAULT_FAIL_ON_UNKNOWN_ATTRIBUTE));
@@ -332,16 +327,10 @@ public class CSVSourceMapper extends SourceMapper {
      * @param delimiter
      * @return
      */
-    private CSVFormat getFormatter(Object delimiter) {
-        CSVFormat csvFormat;
-        if (delimiter instanceof Character) {
-           csvFormat = (Character) delimiter == TAB_DElIMITER ? CSVFormat.TDF :
-                   CSVFormat.Builder.create().setDelimiter((char) delimiter).build();
-        } else {
-            csvFormat = CSVFormat.Builder.create().setDelimiter(delimiter.toString()).build();
-        }
+    private CSVFormat getFormatter(String delimiter) {
+        return Objects.equals(delimiter, TAB_DElIMITER) ? CSVFormat.TDF :
+                CSVFormat.Builder.create().setDelimiter(delimiter).build();
 
-        return csvFormat;
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
         <siddhi.version.range>[5.0.0,6.0.0)</siddhi.version.range>
         <log4j.version>2.17.1</log4j.version>
         <testng.version>6.8</testng.version>
-        <commons.csv.version>1.4</commons.csv.version>
+        <commons.csv.version>1.10.0</commons.csv.version>
         <jacoco.version>0.7.9</jacoco.version>
         <carbon.feature.plugin.version>3.1.1</carbon.feature.plugin.version>
     </properties>


### PR DESCRIPTION
Fixes https://github.com/wso2/api-manager/issues/2144

## Purpose
This PR will add multicharacter delimiter support for Siddhi CSV mapper


## Automation tests
 - Unit tests 
   added for the improvement
 - Integration tests
   N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes